### PR TITLE
Resolve issues left behind by PR#3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Your troubles are long gone with ***Ride Price Manager***!
   - That number is determined by ride rating, ride age, and other factors.
 - You can configure the plugin via the "Ride Price Manager" _control panel_, which is available **under the Map Dropdown** on the top bar. There, you can:
   - disable/re-enable the plugin.
+  - make the plugin ignore free rides. It's useful to make transport rides free, as guests will always take them, no matter how unhappy or unsatisfied they are.
   - tell the plugin to set lower prices if your park also charges admission.
   - tell the plugin to set lower prices to make guests think your rides are "Good Value".
   - add a "Lazy Tax" to decrease ride prices. This is for people that think this plugin is overpowered or just want to re-balance the game a little bit.
   - allow prices greater than $20.00 for high value rides.
     - Guests are willing to pay more than $20 for some rides, but you can't set a price to more than $20 via the UI. This allows the plugin to bypass that check.
-  - ignore free rides. It has certain benefits to make transport rides free, as guests will always take them, no matter how unhappy or unsatisfied they are.
 
 ## Installation
 1. Get a new (enough) version of OpenRCT2 (`v0.2.6-c3921d9` from 2020/05/29 or newer)

--- a/build/ride-price-manager.js
+++ b/build/ride-price-manager.js
@@ -4,18 +4,18 @@
     var namespace = 'RidePriceManager';
     var configPrefix = namespace + '.';
     var goodValueEnabled = configPrefix + 'goodValueEnabled';
+    var ignoreFreeRidesEnabled = configPrefix + 'ignoreFreeRidesEnabled';
     var lazyTaxFactor = configPrefix + 'lazyTaxFactor';
     var parkAdmissionEnabled = configPrefix + 'parkAdmissionEnabled';
     var pluginEnabled = configPrefix + 'pluginEnabled';
     var unboundPriceEnabled = configPrefix + 'unboundPriceEnabled';
-    var ignoreFreeRidesEnabled = configPrefix + 'ignoreFreeRidesEnabled';
     var defaults = {
       goodValueEnabled: false,
+      ignoreFreeRidesEnabled: true,
       lazyTaxFactor: 0,
       parkAdmissionEnabled: false,
       pluginEnabled: true,
-      unboundPriceEnabled: false,
-      ignoreFreeRidesEnabled: false
+      unboundPriceEnabled: false
     };
     var lazyTaxOptions = [{
       s: '0%',
@@ -49,6 +49,12 @@
       setGoodValueEnabled: function (v) {
         return context.sharedStorage.set(goodValueEnabled, v);
       },
+      getIgnoreFreeRidesEnabled: function () {
+        return context.sharedStorage.get(ignoreFreeRidesEnabled, defaults.ignoreFreeRidesEnabled);
+      },
+      setIgnoreFreeRidesEnabled: function (v) {
+        return context.sharedStorage.set(ignoreFreeRidesEnabled, v);
+      },
       getLazyTaxFactor: function () {
         return context.sharedStorage.get(lazyTaxFactor, defaults.lazyTaxFactor);
       },
@@ -72,12 +78,6 @@
       },
       setUnboundPriceEnabled: function (v) {
         return context.sharedStorage.set(unboundPriceEnabled, v);
-      },
-      getIgnoreFreeRidesEnabled: function () {
-        return context.sharedStorage.get(ignoreFreeRidesEnabled, defaults.ignoreFreeRidesEnabled);
-      },
-      setIgnoreFreeRidesEnabled: function (v) {
-        return context.sharedStorage.set(ignoreFreeRidesEnabled, v);
       }
     };
 
@@ -140,7 +140,7 @@
         width: 240,
         height: 125,
         title: 'Ride Price Manager',
-        widgets: [makePluginEnabledCheckbox(20), makeParkAdmissioCheckbox(45), makeGoodValueCheckbox(60), makeLazyTaxLabel(75), makeLazyTaxDropdown(75), makeUnboundPriceCheckbox(92), makeIgnoreFreeRidesCheckbox(107)],
+        widgets: [makePluginEnabledCheckbox(20), makeIgnoreFreeRidesCheckbox(45), makeParkAdmissioCheckbox(60), makeGoodValueCheckbox(75), makeLazyTaxLabel(90), makeLazyTaxDropdown(90), makeUnboundPriceCheckbox(107)],
         onClose: function () {
           window = undefined;
         }
@@ -160,6 +160,12 @@
         isChecked: isChecked,
         onChange: onChange
       };
+    };
+
+    var makeIgnoreFreeRidesCheckbox = function (y) {
+      return makeCheckbox(y, "Prevent the plugin from affecting rides that are currently free. " + "Recommended for transport rides & scenarios with a Park Entrance Fee.", "Ignore free rides", config.getIgnoreFreeRidesEnabled(), function (isChecked) {
+        config.setIgnoreFreeRidesEnabled(isChecked);
+      });
     };
 
     var makeGoodValueCheckbox = function (y) {
@@ -215,12 +221,6 @@
     var makeUnboundPriceCheckbox = function (y) {
       return makeCheckbox(y, "Via the UI, the max price is $20.00 - Enable this to allow the plugin to set higher prices", "Allow unbound prices", config.getUnboundPriceEnabled(), function (isChecked) {
         config.setUnboundPriceEnabled(isChecked);
-      });
-    };
-
-    var makeIgnoreFreeRidesCheckbox = function (y) {
-      return makeCheckbox(y, "Having free transport rides has certain benefits.", "Ignore free rides", config.getIgnoreFreeRidesEnabled(), function (isChecked) {
-        config.setIgnoreFreeRidesEnabled(isChecked);
       });
     };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,19 +4,19 @@ const namespace = 'RidePriceManager';
 const configPrefix = namespace + '.';
 
 const goodValueEnabled = configPrefix + 'goodValueEnabled';
+const ignoreFreeRidesEnabled = configPrefix + 'ignoreFreeRidesEnabled';
 const lazyTaxFactor = configPrefix + 'lazyTaxFactor';
 const parkAdmissionEnabled = configPrefix + 'parkAdmissionEnabled';
 const pluginEnabled = configPrefix + 'pluginEnabled';
 const unboundPriceEnabled = configPrefix + 'unboundPriceEnabled';
-const ignoreFreeRidesEnabled = configPrefix + 'ignoreFreeRidesEnabled';
 
 const defaults = {
     goodValueEnabled: false,
+    ignoreFreeRidesEnabled: true,
     lazyTaxFactor: 0,
     parkAdmissionEnabled: false,
     pluginEnabled: true,
     unboundPriceEnabled: false,
-    ignoreFreeRidesEnabled: false,
 };
 
 type LazyTaxOption = { s: string, n: number };
@@ -42,6 +42,18 @@ const config = {
 
     setGoodValueEnabled: function (v: boolean) {
         return context.sharedStorage.set(goodValueEnabled, v);
+    },
+
+    /**
+     * Having free transport rides has certain benefits.
+     * This setting tells the plugin to ignore free rides.
+     */
+    getIgnoreFreeRidesEnabled: function (): boolean {
+        return context.sharedStorage.get(ignoreFreeRidesEnabled, defaults.ignoreFreeRidesEnabled);
+    },
+
+    setIgnoreFreeRidesEnabled: function (v: boolean) {
+        return context.sharedStorage.set(ignoreFreeRidesEnabled, v);
     },
 
     /**
@@ -92,18 +104,6 @@ const config = {
 
     setUnboundPriceEnabled: function (v: boolean) {
         return context.sharedStorage.set(unboundPriceEnabled, v);
-    },
-
-    /**
-     * Having free transport rides has certain benefits.
-     * This setting tells the plugin to ignore free rides.
-     */
-    getIgnoreFreeRidesEnabled: function (): boolean {
-        return context.sharedStorage.get(ignoreFreeRidesEnabled, defaults.ignoreFreeRidesEnabled);
-    },
-
-    setIgnoreFreeRidesEnabled: function (v: boolean) {
-        return context.sharedStorage.set(ignoreFreeRidesEnabled, v);
     },
 };
 

--- a/src/fixRidePrices.ts
+++ b/src/fixRidePrices.ts
@@ -21,7 +21,7 @@ const updateRidePrice = function (ride: Ride): void {
         return;
     }
 
-    if(ride.price[0] === 0 && config.getIgnoreFreeRidesEnabled()){
+    if (ride.price[0] === 0 && config.getIgnoreFreeRidesEnabled()) {
         // Ignore free rides.
         return;
     }

--- a/src/window.ts
+++ b/src/window.ts
@@ -20,12 +20,12 @@ const showWindow = function (): void {
         title: 'Ride Price Manager',
         widgets: [
             makePluginEnabledCheckbox(20),
-            makeParkAdmissioCheckbox(45),
-            makeGoodValueCheckbox(60),
-            makeLazyTaxLabel(75),
-            makeLazyTaxDropdown(75),
-            makeUnboundPriceCheckbox(92),
-            makeIgnoreFreeRidesCheckbox(107),
+            makeIgnoreFreeRidesCheckbox(45),
+            makeParkAdmissioCheckbox(60),
+            makeGoodValueCheckbox(75),
+            makeLazyTaxLabel(90),
+            makeLazyTaxDropdown(90),
+            makeUnboundPriceCheckbox(107),
         ],
         onClose: () => { window = undefined; },
     };
@@ -50,6 +50,19 @@ const makeCheckbox = function (
         isChecked: isChecked,
         onChange: onChange,
     };
+}
+
+const makeIgnoreFreeRidesCheckbox = function (y: number): CheckboxWidget {
+    return makeCheckbox(
+        y,
+        "Prevent the plugin from affecting rides that are currently free. "
+        + "Recommended for transport rides & scenarios with a Park Entrance Fee.",
+        `Ignore free rides`,
+        config.getIgnoreFreeRidesEnabled(),
+        (isChecked: boolean) => {
+            config.setIgnoreFreeRidesEnabled(isChecked);
+        },
+    );
 }
 
 const makeGoodValueCheckbox = function (y: number): CheckboxWidget {
@@ -126,18 +139,6 @@ const makeUnboundPriceCheckbox = function (y: number): CheckboxWidget {
         config.getUnboundPriceEnabled(),
         (isChecked: boolean) => {
             config.setUnboundPriceEnabled(isChecked);
-        },
-    );
-}
-
-const makeIgnoreFreeRidesCheckbox = function (y: number): CheckboxWidget {
-    return makeCheckbox(
-        y,
-        "Having free transport rides has certain benefits.",
-        `Ignore free rides`,
-        config.getIgnoreFreeRidesEnabled(),
-        (isChecked: boolean) => {
-            config.setIgnoreFreeRidesEnabled(isChecked);
         },
     );
 }


### PR DESCRIPTION
PR https://github.com/mgovea/openrct2-ride-price-manager/pull/3 mostly addressed Issue https://github.com/mgovea/openrct2-ride-price-manager/issues/1 . However, the default was originally `false`, so this obviously beneficial behavior was opt-in instead of opt-out. I wanted to make the default more accessible, and it also has the added benefit of fixing Issue https://github.com/mgovea/openrct2-ride-price-manager/issues/4 for most people.

I also wanted to fix some nits, so I did that.